### PR TITLE
Move linting out of gulp process, use only CLI

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+src/static/scripts/vendor

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+exclude: 'src/static/styles/vendor/**'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 install:
     - composer install
     - npm install
+    - gem install scss-lint
 before_script:
     - composer test
     - npm test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 var gulp = require('gulp');
-var jshint = require('gulp-jshint');
 var autoprefixer = require('gulp-autoprefixer');
 var sass = require('gulp-sass');
 var plumber = require('gulp-plumber');
@@ -14,13 +13,6 @@ var reportError = function(error) {
     // Prevent the 'watch' task from stopping
     this.emit('end');
 };
-
-gulp.task('lint', function() {
-    return gulp.src(['src/static/scripts/**/*.js', 'gulpfile.js', '!src/static/js/vendor'])
-        .pipe(jshint())
-        .pipe(jshint.reporter('jshint-stylish'))
-        .pipe(jshint.reporter('fail'));
-});
 
 gulp.task('styles', function() {
     return gulp.src('src/static/styles/**/*.{scss,css}')

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
-    "gulp-jshint": "^1.11.2",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.0.1",
     "gulp-sass": "^2.0.3",
-    "jshint-stylish": "^2.0.1"
+    "jshint-stylish": "^2.0.1",
+    "jshint": "^2.8.0"
   },
   "scripts": {
-    "test": "gulp lint",
-    "gulp": "gulp"
+    "gulp": "gulp",
+    "test": "jshint src/static/scripts --reporter=node_modules/jshint-stylish && scss-lint src/static/styles/"
   }
 }


### PR DESCRIPTION
The scss-lint (ruby gem) CLI and jshint CLI are used to lint SCSS and JS
instead of putting the linting process in gulp. This makes it simpler to
lint and also decouples the process from gulp and whatever complications
it may bring. Also reduces number of dependencies.
- scss-lint gem required, added in .travis.yml
- Should resolve #4
