### PR TITLE
Exit a failing build if in CI environment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,9 @@ var plumber = require('gulp-plumber');
 var notify = require('gulp-notify');
 
 var reportError = function(error) {
+    if ('CI' in process.env && process.env.CI === 'true') {
+        process.exit(1);
+    }
     notify({
         title: error.plugin + ' failed!',
         message: 'See console.'


### PR DESCRIPTION
Travis CI sets the environment variable CI=true. Changed the gulpfile to
exit when a build fails and CI=true. Resolves #9.
