### PR TITLE
Improve `npm test` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "scripts": {
     "gulp": "gulp",
-    "test": "jshint src/static/scripts --reporter=node_modules/jshint-stylish && scss-lint src/static/styles/"
+    "test": "jshint src/static/scripts gulpfile.js --reporter=node_modules/jshint-stylish; scss-lint src/static/styles/"
   }
 }


### PR DESCRIPTION
- Also run JSHint on gulpfile.js
- Remove `&&` from between jshint and scss-lint, separate using `;` so that
  scss-lint runs even if jshint fails
