### PR TITLE
Ensure that jshint failing fails npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "scripts": {
     "gulp": "gulp",
-    "test": "jshint src/static/scripts gulpfile.js --reporter=node_modules/jshint-stylish; scss-lint src/static/styles/"
+    "test": "scripts/lint.sh"
   }
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo "Running jshint..."
+jshint src/static/scripts gulpfile.js --reporter=node_modules/jshint-stylish
+JSHINT_STATUS=$?
+
+echo "Running scss-lint..."
+scss-lint src/static/styles/
+SCSS_LINT_STATUS=$?
+
+exit $((JSHINT_STATUS || SCSS_LINT_STATUS))


### PR DESCRIPTION
Due to the two test commands being separated by ';', the first command
failing would not fail npm test. Wrote a small bash script that checks
return value of both commands and returns 1 if any errored. `npm test`
now calls that script.

Fixes T45.
