### PR TITLE
Relax scss-lint rules

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -7,3 +7,5 @@ linters:
         enabled: false
     IdSelector:
         enabled: false
+    ColorKeyword:
+        enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -5,3 +5,5 @@ linters:
         width: 4
     ColorVariable:
         enabled: false
+    IdSelector:
+        enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -3,3 +3,5 @@ exclude: 'src/static/styles/vendor/**'
 linters:
     Indentation:
         width: 4
+    ColorVariable:
+        enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,1 +1,5 @@
 exclude: 'src/static/styles/vendor/**'
+
+linters:
+    Indentation:
+        width: 4


### PR DESCRIPTION
- Disabled `ColorVariable`, `IdSelector` and `ColorKeyword` linters.
- Changed expected indentation to 4 spaces.

Resolves T52.
