### PR TITLE
Improve 40x pages and http library's handling of them

### DIFF
--- a/src/app/config-sample.php
+++ b/src/app/config-sample.php
@@ -14,6 +14,8 @@ $cfg = array(
             'db_name'   => 'dbname',
         )
     ),
+    '404_view' => 'http_error',
+    '404_data' => ['error_code' => 404],
 );
 
 $admins = [

--- a/src/app/libraries/http_lib.php
+++ b/src/app/libraries/http_lib.php
@@ -1,14 +1,21 @@
 <?php
 
 class http_lib extends Library {
-
     function response_code($code, $view_and_exit = true, $view_name = false) {
         http_response_code($code);
         if ($view_and_exit) {
             if (empty($view_name)) {
                 $view_name = strval($code);
             }
-            $this->load_view($view_name);
+            // Check if a dedicated view exists; if not, load common error view
+            $dedicated_view = $this->load_view($view_name, [
+                'error_code' => $code,
+            ]);
+            if (! $dedicated_view) {
+                $this->load_view('http_error', [
+                    'error_code' => $code,
+                ]);
+            }
             exit();
         }
     }

--- a/src/app/views/403.php
+++ b/src/app/views/403.php
@@ -1,1 +1,0 @@
-403 - Access denied

--- a/src/app/views/404.php
+++ b/src/app/views/404.php
@@ -1,1 +1,0 @@
-404 - Page not found

--- a/src/app/views/http_error.php
+++ b/src/app/views/http_error.php
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $error_code ?><?php if (isset($message)) echo " - ", $message; ?></title>
+    <link rel="stylesheet" href="<?= base_url() ?>static/styles/error.css">
+</head>
+<body>
+    <div id="container">
+    <h2><?= $error_code ?></h2>
+    <div class="messages">
+    <?php
+    switch ($error_code) {
+        case '400':
+            $message = 'Invalid request!';
+            $message_details = 'Your browser sent an invalid request. Please try again.';
+            break;
+        case '403':
+            $message = 'Forbidden!';
+            $message_details = 'Sorry, you do not have permission to view this page.';
+            break;
+        case '404':
+            $message = 'Page not found!';
+            $message_details = 'Sorry, the page you were looking for could not be found.';
+            break;
+        default:
+            $message = 'Something went wrong.';
+            $message_details = 'If this issue persists, please mail'
+                . ' <a href="mailto:help@felicity.iiit.ac.in">help@felicity.iiit.ac.in</a>.';
+    }
+    ?>
+        <?php if (isset($message)): ?>
+            <h1><?= $message ?></h1>
+        <?php endif; if (isset($message_details)): ?>
+            <p><?= $message_details ?></p>
+        <?php endif; ?>
+    </div>
+    <p><a href="<?= base_url() ?>">&lt;&lt; Felicity ʼ16 Home</a></p>
+    <p><a href="javascript:history.back()">&lt;&lt; Back</a></p>
+    </div>
+</body>
+</html>

--- a/src/static/styles/error.css
+++ b/src/static/styles/error.css
@@ -1,0 +1,55 @@
+::selection {
+    background-color: #2094cf;
+    color: white;
+}
+
+::moz-selection {
+    background-color: #2094cf;
+    color: white;
+}
+
+::webkit-selection {
+    background-color: #2094cf;
+    color: white;
+}
+
+body {
+    background-color: #f2f2f2;
+    margin: 40px;
+    font-family: 'Verdana', sans-serif;
+    font-size: 24px;
+}
+
+h1,
+h2 {
+    font-weight: 400;
+}
+
+h1 {
+    font-size: 3em;
+}
+
+h2 {
+    font-size: 2.5em;
+    color: #999;
+}
+
+.messages p {
+    color: #666;
+}
+
+#container {
+    margin: auto;
+    text-align: center;
+}
+
+a {
+    color: #08c;
+    text-decoration: none;
+}
+
+@media (max-width: 600px) {
+    body {
+        font-size: 16px;
+    }
+}


### PR DESCRIPTION
Keep just one 40x page and output the error code and message inside
that. Keep a list of codes and messages in http_lib.

Styling of 40x page is currently arbitrary - can be improved when rest
of the site is styled.

Resolves T90.
