### PR TITLE
Update Travis CI conf to test on PHP 5.5.9 and PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: php
+php:
+    - 5.5.9
+    - 7.0
+matrix:
+    allow_failures:
+        - php: 7.0
+    fast_finish: true
 install:
   - composer install
   - npm install


### PR DESCRIPTION
PHP 7 build is allowed to fail, and the build is _marked_ as finished when
5.5.9 completes (does not wait for 7, since it is allowed to fail). This
means we'll have to look at the Travis console output for compatibility
issues - but we'll get faster completing builds.

Should resolve T84.
