### PR TITLE
Disable PseudoElement SCSS lint rule

### DIFF
--- a/.css-lint.yml
+++ b/.css-lint.yml
@@ -14,6 +14,8 @@ linters:
         max_depth: 4
     PropertySortOrder:
         enabled: false
+    PseudoElement:
+        enabled: false
 
 # CSS specific stuff
     MergeableSelector:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -14,3 +14,5 @@ linters:
         max_depth: 4
     PropertySortOrder:
         enabled: false
+    PseudoElement:
+        enabled: false


### PR DESCRIPTION
There are certain issues with this rule that are being fixed upstream
and this isn't too important for us. Disabling for now.
