### PR TITLE
Add flash_append method to session_lib

### DIFF
--- a/src/app/libraries/session_lib.php
+++ b/src/app/libraries/session_lib.php
@@ -21,6 +21,22 @@ class session_lib extends Library {
     }
 
     /**
+     * Append to an array in flash data
+     * If the array does not exist, create it and then append
+     * @param string $name
+     * @param mixed  $value
+     */
+    public function flash_append($name, $value) {
+        if (!isset($_SESSION["_flashdata"])) {
+            $_SESSION["_flashdata"] = [];
+        }
+        if (!isset($_SESSION["_flashdata"][$name])) {
+            $_SESSION["_flashdata"][$name] = [];
+        }
+        $_SESSION["_flashdata"][$name][] = $value;
+    }
+
+    /**
      * Get and unset flash data
      * @param  string     $name
      * @return mixed|null       Value of the set flashed data


### PR DESCRIPTION
This lets you append to an array in the flash data, creating one first
if it does not exist. This is particularly useful in cases such as
errors, `$this->session_lib->flash_append('errors', 'foo bar');` lets you
append errors from anywhere in the code without worrying about whether
the 'errors' array exists in the flash data.
