### PR TITLE
Returning null if default value, not something random

### DIFF
--- a/src/app/models/jugaad_model.php
+++ b/src/app/models/jugaad_model.php
@@ -601,9 +601,9 @@ class jugaad_model extends Model {
             $field = $this->get_field_value($file_id, $name, $meta, $user);
             if ($field === false) {
                 if ($return_default) {
-                    $data[$name] = @$meta['default'] ?: $meta['name'];
+                    $data[$name] = @$meta['default'] ?: null;
                 } else {
-                    $data[$name] = '';
+                    $data[$name] = null;
                 }
             } else {
                 $data[$name] = $field;


### PR DESCRIPTION
If a field is optional, and neither that it set, nor its
default value, then return null, instead of some random
value.
